### PR TITLE
[#10] PostCard 컴포넌트 디자인 수정

### DIFF
--- a/src/app/boards/_components/boards-best/boards-best-post/boards-best-post.tsx
+++ b/src/app/boards/_components/boards-best/boards-best-post/boards-best-post.tsx
@@ -64,7 +64,7 @@ const BoardBestPost = () => {
         >
           {visiblePosts.map((post) => (
             <PostCard
-              className="w-full max-w-[340px] py-5 tablet:max-w-[304px] tablet:px-5 pc:h-[206px] pc:max-w-[350px] pc:py-6"
+              className="h-[177px] w-full max-w-[340px] py-5 tablet:max-w-[304px] tablet:px-5 pc:h-[206px] pc:max-w-[350px] pc:py-6"
               key={post.id}
               {...post}
               isBest={true}

--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -49,8 +49,20 @@ const PostCard = ({
                 isBest && "mobile:h-[67px] tablet:h-[67px] pc:h-[71px]"
               )}
             >
-              <p className="truncate text-lg font-bold">{title}</p>
-              <p className="line-clamp-2 h-[42px] resize-none truncate whitespace-pre text-sm leading-[18px] text-gray-800">
+              <p
+                className={cn(
+                  "truncate text-lg font-bold tablet:text-2lg",
+                  isBest && "tablet:text-lg pc:text-2lg"
+                )}
+              >
+                {title}
+              </p>
+              <p
+                className={cn(
+                  "line-clamp-2 h-[42px] resize-none truncate whitespace-pre text-sm leading-[18px] text-gray-800 tablet:text-md",
+                  isBest && "tablet:text-sm pc:text-md"
+                )}
+              >
                 {content}
               </p>
             </div>
@@ -71,11 +83,16 @@ const PostCard = ({
         </div>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">{writer}</span>
+            <span className={cn("text-sm font-medium", isBest && "pc:text-md")}>
+              {writer}
+            </span>
             <span className="text-sm">|</span>
             <time
               dateTime={createdAt}
-              className="text-sm font-medium text-gray-700"
+              className={cn(
+                "text-sm font-medium text-gray-700",
+                isBest && "pc:text-md"
+              )}
             >
               {toDotDateString(createdAt)}
             </time>


### PR DESCRIPTION
<!-- PR 제목은 '[#이슈번호] 작업 내용 요약'으로 통일해주세요. -->

## 📄 PR 내용 요약

게시판 페이지에 사용되는 PostCard 컴포넌트 수정했습니다.

## ✅ 작업 내용 상세

- 해당 컴포넌트의 여백을 전체적으로 수정했습니다.
- 특히 "인기" 카드는 조건부 여백을 추가로 작성했습니다.

## 📸 스크린샷 (선택사항)
<img width="1136" height="939" alt="스크린샷 2025-11-14 16 53 01" src="https://github.com/user-attachments/assets/3f089785-9d09-444d-bcc6-571b61d89fe8" />


## 💬 참고 사항

- BoardsBestPost 컴포넌트에 있는 PostCard 부분에 스타일을 추가했습니다. conflict가 발생할 수 있으니 주의해주세요!

## 📝 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거
