### PR TITLE
[#112] 자유게시판 게시글 작성 플로팅 버튼 추가

### DIFF
--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button, Icon } from "@/components/index";
 import BoardsHeader from "./_components/boards-header/boards-header";
 import BoardsBest from "./_components/boards-best/boards-best";
 import BoardsAll from "./_components/boards-all/boards-all";
@@ -21,6 +23,11 @@ const Page = () => {
       <BoardsHeader onSearch={setKeyword} />
       <BoardsBest />
       <BoardsAll keyword={debounceKeyword} />
+      <Link href="/boards/write">
+        <Button className="fixed bottom-10 right-[13%] z-50 h-14 w-14 rounded-full">
+          <Icon icon="pencil" className="h-6 w-6" />
+        </Button>
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## 📄 PR 내용 요약

- 자유게시판 메인페이지 플로팅 버튼 추가

## ✅ 작업 내용 상세

- `page.tsx` 파일에 `Link` + `Button + Icon` 형태로 플로팅 버튼 추가하였습니다.

## 📸 스크린샷 (선택사항)

### PC
<img width="1175" height="734" alt="Screenshot 2025-11-18 at 15 56 09" src="https://github.com/user-attachments/assets/5f70a72d-8184-4e09-871c-ac5482f38498" />

### Tablet
<img width="494" height="580" alt="Screenshot 2025-11-18 at 16 01 48" src="https://github.com/user-attachments/assets/ce0c74be-c23f-42e9-ac1f-9bbe4b8923be" />


### Mobile
<img width="375" height="616" alt="Screenshot 2025-11-18 at 16 01 37" src="https://github.com/user-attachments/assets/5ce04d0f-c37e-464a-bb03-bc9bc794700b" />

## 💬 참고 사항

- 위치는 휘태님이 작성하신 스타일 그대로 사용했습니다!

## 📝 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거
